### PR TITLE
fix warning tune.c when compiling

### DIFF
--- a/kernel/sched/tune.c
+++ b/kernel/sched/tune.c
@@ -637,10 +637,10 @@ int schedtune_prefer_idle(struct task_struct *p)
 static u64
 prefer_idle_read(struct cgroup_subsys_state *css, struct cftype *cft)
 {
+	struct schedtune *st = css_st(css);
+	
 	if (is_battery_saver_on())
 		return 0;
-
-	struct schedtune *st = css_st(css);
 
 	return st->prefer_idle;
 }
@@ -658,10 +658,10 @@ prefer_idle_write(struct cgroup_subsys_state *css, struct cftype *cft,
 static s64
 boost_read(struct cgroup_subsys_state *css, struct cftype *cft)
 {
+	struct schedtune *st = css_st(css);
+	
 	if (is_battery_saver_on())
 		return 0;
-
-	struct schedtune *st = css_st(css);
 
 	return st->boost;
 }


### PR DESCRIPTION
fix warning tune.c: iso c90 forbids mixing declarations and code 
beautify the code